### PR TITLE
Fix some rough edges, primarily around quasigroups and semilattices

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: test lib
+all: test lib stdlib-doc
 
 DEPLOY_DEST ?= vps:/var/www/naproche.org/
 RSYNC_FLAGS ?= -az --delete-delay --itemize-changes --exclude=".DS_Store"
@@ -25,27 +25,31 @@ test:
 publish:
 	rsync $(RSYNC_FLAGS) html/ $(DEPLOY_DEST)
 
-.PHONE: profile
+.PHONY: profile
 profile:
 	stack --work-dir .stack-work-profile build --profile --ghc-options "-fprof-auto -fprof-cafs"
 	stack --work-dir .stack-work-profile exec --profile zf -- debug/formalizations_with_section_20_up_to_euclidean_metric_theorem.tex --uncached +RTS -s -p
 	ghc-prof-flamegraph zf.prof
 
-.PHONE: profilenominal
+.PHONY: profilenominal
 profilenominal:
 	stack --work-dir .stack-work-profile build --profile --ghc-options "-fprof-auto -fprof-cafs"
 	stack --work-dir .stack-work-profile exec --profile zf -- debug/formalizations_with_section_20_up_to_euclidean_metric_theorem.tex --nominal --uncached +RTS -s -p
 	ghc-prof-flamegraph zf.prof
 
-.PHONE: profilemem
+.PHONY: profilemem
 profilemem:
 	stack --work-dir .stack-work-profile build --profile --ghc-options "-fprof-auto -fprof-cafs"
 	stack --work-dir .stack-work-profile exec --profile zf -- debug/formalizations_with_section_20_up_to_euclidean_metric_theorem.tex --uncached +RTS -hc -RTS
 	hp2ps zf.hp
 	gs -q -dNOPAUSE -dBATCH -sOutputFile=temp.ps -sDEVICE=ps2write -c "<</Orientation 1>> setpagedevice" -- zf.ps && mv temp.ps zf.ps
 
-.PHONE: profileparser
+.PHONY: profileparser
 profileparser:
 	stack --work-dir .stack-work-profile build --profile --ghc-options "-fprof-auto -fprof-cafs"
 	stack --work-dir .stack-work-profile exec --profile zf -- debug/formalizations_with_section_20_up_to_euclidean_metric_theorem.tex --parseonly --uncached +RTS -p
 	ghc-prof-flamegraph zf.prof
+
+.PHONY: stdlib-doc
+stdlib-doc:
+	cd latex && xelatex stdlib.tex && xelatex stdlib.tex && xelatex stdlib.tex

--- a/latex/naproche.sty
+++ b/latex/naproche.sty
@@ -61,6 +61,7 @@
 \crefname{abbreviation}{abbreviation}{abbreviations}
 \crefname{proposition}{proposition}{propositions}
 \crefname{lemma}{lemma}{lemmas}
+\crefname{struct}{struct}{structs}
 
 \newcommand{\fun}[1]{\operatorname{\mathsf{#1}}}
 
@@ -158,6 +159,8 @@
 \newcommand{\at}[2]{#1(#2)}
 \newcommand{\intervalopenInfiniteLeft}[1]{(-\infty, #1)}
 \newcommand{\intervalopenInfiniteRight}[1]{(#1, \infty)}
+\newcommand{\qdivl}{\backslash}
+\newcommand{\qdivr}{/}
 
 
 \newcommand\restrl[2]{{% we make the whole thing an ordinary symbol
@@ -177,8 +180,8 @@
 % Structure operations
 
 \newcommand{\carrier}[1][]{#1}
-\newcommand{\mul}[1][]{\textsf{mul}_{#1}}
-\newcommand{\neutral}[1][]{\textsf{e}_{#1}}
+\newcommand{\mul}[1][]{\operatorname{mul}_{#1}}
+\newcommand{\neutral}[1][]{\operatorname{e}_{#1}}
 \newcommand{\lt}[1][]{\leq_{#1}}
 \newcommand{\opens}[1][]{\mathcal{O}_{#1}}
 \newcommand{\meet}[1][]{\sqcap_{#1}}
@@ -190,8 +193,8 @@
 \newcommand{\closures}[2]{\fun{Cl}_{#2}{#1}}
 \newcommand{\closure}[2]{\fun{cl}_{#2}{#1}}
 \newcommand{\frontier}[2]{\fun{fr}_{#2}{#1}}
-\newcommand{\neighbourhoods}[2]{\textsf{N}_{#2}{#1}}
-\newcommand{\neighbourhoodsSet}[2]{\textsf{N}_{SET #2}{#1}}
+\newcommand{\neighbourhoods}[2]{\operatorname{N}_{#2}{#1}}
+\newcommand{\neighbourhoodsSet}[2]{\operatorname{N}_{SET #2}{#1}}
 \newcommand{\disconnections}[1]{\fun{Disconnections}{#1}}
 
 \newcommand{\teezero}{\ensuremath{T_0}} % Kolmogorov

--- a/latex/stdlib.tex
+++ b/latex/stdlib.tex
@@ -34,15 +34,16 @@
     \input{../library/ordinal.tex}
     \input{../library/nat.tex}
     \input{../library/cardinal.tex}
+    \input{../library/set/equinumerosity.tex}
     \input{../library/algebra/magma.tex}
     \input{../library/algebra/semigroup.tex}
     \input{../library/algebra/monoid.tex}
-    \input{../library/algebra/group.tex}
-    %\input{../library/algebra/quasigroup.tex}
-    %\input{../library/algebra/loop.tex}
+    \input{../library/algebra/quasigroup.tex}
+    \input{../library/algebra/loop.tex}
     \input{../library/order/order.tex}
     \input{../library/order/semilattice.tex}
     \input{../library/topology/topological-space.tex}
     \input{../library/topology/basis.tex}
     \input{../library/topology/disconnection.tex}
+    \input{../library/topology/separation.tex}
 \end{document}

--- a/library/algebra/quasigroup.tex
+++ b/library/algebra/quasigroup.tex
@@ -2,35 +2,52 @@
 
 \section{Quasigroups}
 
+\newcommand{\ldiv}[1][]{\operatorname{ldiv}_{#1}}
+\newcommand{\rdiv}[1][]{\operatorname{rdiv}_{#1}}
+
 \begin{struct}\label{quasigroup}
-    A quasigroup $A$ is a magma equipped with
-    \begin{enumerate}
-        \item $\ldiv$
-        \item $\rdiv$
-    \end{enumerate}
-    such that
-    \begin{enumerate}
-        \item for all $a, b\in A$ we have $\ldiv (a,b)\in A$.
-        \item for all $a, b\in A$ we have $\rdiv (a,b)\in A$.
-        \item for all $a,b \in A$ we have $b = \mul(a,\ldiv (a,b))$.
-        \item for all $a,b \in A$ we have $b = \ldiv(a,\mul (a,b))$.
-        \item for all $a,b \in A$ we have $b = \mul(\rdiv (b,a),a)$.
-        \item for all $a,b \in A$ we have $b = \rdiv(\mul (b,a),a)$.
-    \end{enumerate}
+  A quasigroup $A$ is a magma equipped with
+  \begin{enumerate}
+      \item $\ldiv$
+      \item $\rdiv$
+  \end{enumerate}
+  such that
+  \begin{enumerate}
+      \item\label{quasigroup_ldiv} for all $a, b\in \carrier[A]$ we have $\ldiv[A](a, b) \in \carrier[A]$.
+      \item\label{quasigroup_rdiv} for all $a, b\in \carrier[A]$ we have $\rdiv[A](a, b) \in \carrier[A]$.
+      \item\label{quasigroup_mul_ldiv} for all $a,b \in \carrier[A]$ we have $b = \mul[A](a, \ldiv[A](a, b))$.
+      \item\label{quasigroup_ldiv_mul} for all $a,b \in \carrier[A]$ we have $b = \ldiv[A](a, \mul[A](a, b))$.
+      \item\label{quasigroup_mul_rdiv} for all $a,b \in \carrier[A]$ we have $b = \mul[A](\rdiv[A](b, a), a)$.
+      \item\label{quasigroup_rdiv_mul} for all $a,b \in \carrier[A]$ we have $b = \rdiv[A](\mul[A](b, a), a)$.
+  \end{enumerate}
 \end{struct}
+
+\begin{abbreviation}\label{qdivl_abbr}
+    $a \qdivl b = \ldiv(a,b)$.
+\end{abbreviation}
+
+\begin{abbreviation}\label{qdivr_abbr}
+    $a \qdivr b = \rdiv(a,b)$.
+\end{abbreviation}
 
 % Cancelling an element on the left.
 \begin{lemma}\label{quasigroup_cancel_left}
     Let $A$ be a quasigroup.
-    Let $a,b,c \in A$.
-    Suppose $\mul(a,b) = \mul(a,c)$.
+    Let $a,b,c \in \carrier[A]$.
+    Suppose $a \cdot b = a \cdot c$.
     Then $b = c$.
 \end{lemma}
+\begin{proof}
+  Omitted.
+\end{proof}
 
 % Cancelling an element on the right.
 \begin{lemma}\label{quasigroup_cancel_right}
     Let $A$ be a quasigroup.
-    Let $a,b,c \in A$.
-    Suppose $\mul(a,c) = \mul(b,c)$.
+    Let $a,b,c \in \carrier[A]$.
+    Suppose $a \cdot c = b \cdot c$.
     Then $a = b$.
 \end{lemma}
+\begin{proof}
+  Omitted.
+\end{proof}

--- a/library/everything.tex
+++ b/library/everything.tex
@@ -1,5 +1,6 @@
 \import{set.tex}
 \import{set/cons.tex}
+\import{set/suc.tex}
 \import{set/symdiff.tex}
 \import{set/product.tex}
 \import{set/powerset.tex}
@@ -7,6 +8,7 @@
 \import{set/partition.tex}
 \import{set/cantor.tex}
 \import{set/filter.tex}
+\import{set/regularity.tex}
 \import{set/fixpoint.tex}
 \import{relation.tex}
 \import{relation/properties.tex}
@@ -18,11 +20,14 @@
 \import{ordinal.tex}
 \import{nat.tex}
 \import{cardinal.tex}
+\import{set/equinumerosity.tex}
 \import{algebra/magma.tex}
 \import{algebra/semigroup.tex}
 \import{algebra/monoid.tex}
+\import{algebra/quasigroup.tex}
+\import{algebra/loop.tex}
 \import{order/order.tex}
-%\import{order/semilattice.tex}
+\import{order/semilattice.tex}
 \import{topology/topological-space.tex}
 \import{topology/basis.tex}
 \import{topology/disconnection.tex}

--- a/library/lexicon.csv
+++ b/library/lexicon.csv
@@ -4,3 +4,4 @@ rminus,infix,\rminus
 rmul,infix,\rmul
 rfrac,infix,\rfrac
 rless,rel,\rless
+wedge,infix,\wedge

--- a/library/lexicon.tsv
+++ b/library/lexicon.tsv
@@ -155,6 +155,7 @@ operator	unit_rationals_zero	0	<msub><mi>ℚ</mi><mi>unit0</mi></msub>
 operator	urysohn_admissible	6	<mi>Adm</mi><mo>(</mo><x1/><mo>,</mo><x2/><mo>,</mo><x3/><mo>,</mo><x4/><mo>,</mo><x5/><mo>,</mo><x6/><mo>)</mo>
 operator	urysohn_good_pairs	5	<mi>GoodPairs</mi><mo>(</mo><x1/><mo>,</mo><x2/><mo>,</mo><x3/><mo>,</mo><x4/><mo>,</mo><x5/><mo>)</mo>
 operator	urysohn_level_set	2	<msub><mi>L</mi><x1/></msub><mo>(</mo><x2/><mo>)</mo>
+operator	wedge	2	<mi>∧</mi>
 relation	real_at_least	0	<mo>≥</mo>
 relation	real_at_most	0	<mo>≤</mo>
 relation	real_gt	0	<mo>&gt;</mo>

--- a/library/order/semilattice.tex
+++ b/library/order/semilattice.tex
@@ -1,41 +1,70 @@
-\import{order/partial-order.tex}
+\import{relation.tex}
+\import{relation/properties.tex}
 
-\begin{struct}\label{meet_semilattice}
-    A meet semilattice $X$ is a partial order
-    equipped with
-    \begin{enumerate}
-        \item $\meet$
-    \end{enumerate}
-    such that
-    \begin{enumerate}
-        \item\label{meet_type} for all $x,y\in \carrier[X]$ we have
-           $\meet[X](x,y)\in X$.
-        \item\label{meet_lb} for all $x,y\in \carrier[X]$ we have
-            $\meet[X](x,y) \mathrel{\lt[X]} x, y$.
-        \item\label{meet_glb} for all $a,x,y\in \carrier[X]$ such that $a\mathrel{\lt[X]} x, y$ we have
-            $a\mathrel{\lt[X]} \meet[X](x,y)$.
-    \end{enumerate}
+\begin{struct}\label{partially_ordered_set}
+  A partially ordered set $X$ is a onesorted structure equipped with
+  \begin{enumerate}
+      \item $\lt$
+  \end{enumerate}
+  such that
+  \begin{enumerate}
+      \item\label{partially_ordered_type} $\lt[X]$ is a binary relation on $\carrier[X]$.
+      \item\label{partially_orderd_refl} $\lt[X]$ is reflexive on $\carrier[X]$.
+      \item\label{partially_ordered_refl} $\lt[X]$ is antisymmetric.
+      \item\label{partially_ordered_tran} $\lt[X]$ is transitive.
+  \end{enumerate}
 \end{struct}
 
+\begin{signature}\label{wedge_is_set}
+  $x \wedge y$ is a set.
+\end{signature}
+
+\begin{struct}\label{meet_semilattice}
+  A meet semilattice $X$ is a partially ordered set equipped with
+  \begin{enumerate}
+      \item $\wedge$
+  \end{enumerate}
+  such that
+  \begin{enumerate}
+      \item\label{meet_type} for all $x,y \in \carrier[X]$ we have $x \wedge y \in \carrier[X]$.
+      \item\label{meet_lb} for all $x,y \in \carrier[X]$ we have $x \wedge y \mathrel{\lt[X]} x, y$.
+      \item\label{meet_glb} for all $a,x,y \in \carrier[X]$ such that $a \mathrel{\lt[X]} x, y$ we have $a \mathrel{\lt[X]} x \wedge y$.
+  \end{enumerate}
+\end{struct}
 
 \begin{proposition}\label{meet_idempotent}
-    Let $X$ be a meet semilattice.
-    Then $\meet(x,x) = x$.
+  Let $X$ be a meet semilattice.
+  Suppose $x \in \carrier[X]$. Then $x \wedge x = x$.
 \end{proposition}
 \begin{proof}
-    $\meet(x,x) \mathrel{\lt} x$.
-    $x\mathrel{\lt[X]} x, x$.
-    Thus $x\mathrel{\lt[X]} \meet(x,x)$.
+  $x \mathrel{\lt} x$.
+  Therefore $x \mathrel{\lt} x \wedge x$ by \cref{meet_glb}.
+  $x \wedge x \mathrel{\lt} x$ by \cref{meet_lb}.
 \end{proof}
 
-%\begin{proposition}\label{meet_comm}
-%    Let $X$ be a meet semilattice.
-%    Suppose $x, y\in X$.
-%    Then $\meet(x,y) = \meet(y,x)$.
-%\end{proposition}
+\begin{proposition}\label{meet_comm}
+  Let $X$ be a meet semilattice.
+  Suppose $x, y\in \carrier[X]$.
+  Then $x \wedge y = y \wedge x$.
+\end{proposition}
+\begin{proof}
+  $x \wedge y, y \wedge x \mathrel{\lt} x,y$ by \cref{meet_lb}.
+  Thus $x \wedge y \mathrel{\lt} y \wedge x \mathrel{\lt} x \wedge y$.
+\end{proof}
 
-%\begin{proposition}\label{meet_assoc}
-%    Let $X$ be a meet semilattice.
-%    Suppose $x, y, z\in X$.
-%    Then $\meet(x,\meet(y,z)) = \meet(\meet(x,y),z)$.
-%\end{proposition}
+\begin{proposition}\label{meet_assoc}
+  Let $X$ be a meet semilattice.
+  Suppose $x, y, z\in \carrier[X]$.
+  Then $x \wedge (y \wedge z) = (x \wedge y) \wedge z$.
+\end{proposition}
+\begin{proof}
+  $x \wedge (y \wedge z) \mathrel{\lt} x, y \wedge z$ and $y \wedge z \mathrel{\lt} y, z$ by \cref{meet_semilattice}.
+  Thus $x \wedge (y \wedge z) \mathrel{\lt} (x \wedge y), z$.
+  Thus $x \wedge (y \wedge z) \mathrel{\lt} (x \wedge y) \wedge z$.
+
+  $(x \wedge y) \wedge z \mathrel{\lt} x \wedge y, z$ and $x \wedge y \mathrel{\lt} x, y$.
+  Thus $(x \wedge y) \wedge z \mathrel{\lt} x, y \wedge z$.
+  Thus $(x \wedge y) \wedge z \mathrel{\lt} x \wedge (y \wedge z)$.
+
+  Thus $(x \wedge y) \wedge z \mathrel{\lt} x \wedge (y \wedge z) \mathrel{\lt} (x \wedge y) \wedge z$.
+\end{proof}

--- a/library/relation/properties.tex
+++ b/library/relation/properties.tex
@@ -139,7 +139,7 @@
 \end{definition}
 
 % Also called "connected" (here reserved for topology),
-% "complete" (heavily overloaded), and total" (also overloaded).
+% "complete" (heavily overloaded), and "total" (also overloaded).
 \begin{definition}\label{connex}
     $R$ is connex on $X$ iff
     for all $x, y\in X$ such that $x\neq y$ we have

--- a/library/subfinite.tex
+++ b/library/subfinite.tex
@@ -10,3 +10,7 @@
 \begin{proposition}\label{emptyset_subfinite}
     $\emptyset$ is subfinite.
 \end{proposition}
+
+\begin{proposition}\label{subfinite_universe}
+  Suppose $X$ is a set. Then $X$ is subfinite.
+\end{proposition}

--- a/library/topology/preclosure.tex
+++ b/library/topology/preclosure.tex
@@ -2,17 +2,16 @@
 
 \section{Preclosure spaces}
 
-
-\begin{struct}
+\begin{struct}\label{preclosure}
     A preclosure space $X$ is a onesorted structure equipped with
     \begin{enumerate}
         \item $\cl$
     \end{enumerate}
     such that
     \begin{enumerate}
-        \item For all $Y\subseteq X$ we have $\cl(Y)\subseteq X$.
-        \item $\cl(\emptyset) = \emptyset$.
-        \item For all $A$ we have $A\subseteq \cl(A)$.
-        \item For all $A, B$ we have $\cl(A\union B) = \cl(A) \union \cl(B)$.
+        \item\label{preclosure_closed} For all $Y\subseteq X$ we have $\cl(Y)\subseteq X$.
+        \item\label{preclosure_emptyset} $\cl(\emptyset) = \emptyset$.
+        \item\label{preclosure_increasing} For all $A$ we have $A\subseteq \cl(A)$.
+        \item\label{preclosure_union_commutes} For all $A, B$ we have $\cl(A\union B) = \cl(A) \union \cl(B)$.
     \end{enumerate}
 \end{struct}

--- a/source/Checking.hs
+++ b/source/Checking.hs
@@ -1511,8 +1511,8 @@ checkStructDefn StructDefn{..} = do
     let structContext = structContextFromSymbols structDefnLabel (structDefnFixes <> parentSymbols)
     let isStruct p = TermSymbol Nowhere (SymbolPredicate (PredicateNounStruct p)) [TermVar structDefnLabel]
     let intro = if structParents == Set.singleton _Onesorted
-            then makeConjunction (snd <$> structDefnAssumes) `Implies` isStruct structPhrase
-            else makeConjunction ([isStruct parent | parent <- toList structParents] <> (snd <$> structDefnAssumes)) `Implies` isStruct structPhrase
+            then makeConjunction (snd <$> structDefnAssumes) `Iff` isStruct structPhrase
+            else makeConjunction ([isStruct parent | parent <- toList structParents] <> (snd <$> structDefnAssumes)) `Iff` isStruct structPhrase
     let intro' = (m, intro)
     let inherit' = (Marker (m_ <> "inherit"), isStruct structPhrase `Implies` makeConjunction [isStruct parent | parent <- toList structParents])
     let elims' = [(marker, isStruct structPhrase `Implies` phi) | (marker, phi) <- structDefnAssumes]

--- a/source/Syntax/Token.hs
+++ b/source/Syntax/Token.hs
@@ -346,7 +346,7 @@ beginToplevelEnvironment = lexeme do
 -- | Parses tokens, switching tokenizing frames when encountering math and text environments.
 environment :: Lexer [Located Token]
 environment = do
-    env <- skipManyTill anySingle beginToplevelEnvironment
+    env <- skipManyTill (comment <|> void anySingle) beginToplevelEnvironment
     lts <- go (unLocated env) id
     pure ((BeginEnv <$> env) : lts)
     where


### PR DESCRIPTION
To motivate the change to the tokenizer, try to run this as-is and then after deleting the comment:

```LaTeX
\begin{struct}\label{magma} A magma $A$ is a onesorted structure. \end{struct}

\section{Q}

% \begin{proposition}

\begin{signature}\label{rdiv_is_set} $x \rdiv y$ is a set. \end{signature}
```